### PR TITLE
Add STEP to STL conversion and rendering steps, fix KiCad export commands

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -62,6 +62,8 @@ jobs:
           git add --force hardware/exports/schematic.pdf
           git add --force hardware/exports/gerbers
           git add --force hardware/exports/growbeam.step
+          git add --force hardware/exports/growbeam.stl
+          git add --force hardware/exports/growbeam.png
 
       - name: Commit and Push Generated Files
         run: |

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace kicad9-ci bash -c "
               mkdir -p /workspace/hardware/exports &&
-              kicad-cli sch run-erc /workspace/hardware/kicad_project/*.kicad_sch ||
+              kicad-cli sch erc /workspace/hardware/kicad_project/*.kicad_sch ||
                 echo 'ERC completed with warnings or errors' &&
-              kicad-cli pcb run-drc /workspace/hardware/kicad_project/*.kicad_pcb ||
+              kicad-cli pcb drc /workspace/hardware/kicad_project/*.kicad_pcb ||
                 echo 'DRC completed with warnings or errors' &&
               kicad-cli sch export bom /workspace/hardware/kicad_project/*.kicad_sch -o /workspace/hardware/bom.csv &&
               kicad-cli sch export pdf /workspace/hardware/kicad_project/*.kicad_sch -o /workspace/hardware/exports/schematic.pdf &&

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -38,6 +38,22 @@ jobs:
               kicad-cli pcb export step /workspace/hardware/kicad_project/*.kicad_pcb -o /workspace/hardware/exports/growbeam.step
             "
 
+      - name: Convert STEP to STL using FreeCAD
+        run: |
+          sudo apt-get update && sudo apt-get install -y freecad
+          freecadcmd render/export-stl.py
+
+      - name: Render board with Blender
+        run: |
+          sudo apt-get install -y blender
+          blender -b -P render/render.py
+
+      - name: Upload rendered image
+        uses: actions/upload-artifact@v4
+        with:
+          name: growbeam-render
+          path: render/output.png            
+
       - name: Force Add Generated Files
         run: |
           git config user.name "github-actions[bot]"

--- a/render/export-stl.py
+++ b/render/export-stl.py
@@ -1,0 +1,10 @@
+import FreeCAD, Import
+import os
+
+# Load STEP file
+doc = FreeCAD.newDocument()
+Import.insert(os.path.abspath("hardware/exports/growbeam.step"), doc.Name)
+
+# Export as STL
+part = doc.Objects[0]
+part.Shape.exportStl(os.path.abspath("render/growbeam.stl"))

--- a/render/render.py
+++ b/render/render.py
@@ -1,0 +1,29 @@
+import bpy
+import os
+
+# Clean default scene
+bpy.ops.wm.read_factory_settings(use_empty=True)
+
+# Import STL
+bpy.ops.import_mesh.stl(filepath=os.path.join(os.getcwd(), "render/growbeam.stl"))
+
+# Set up camera
+cam_data = bpy.data.cameras.new("Camera")
+cam = bpy.data.objects.new("Camera", cam_data)
+bpy.context.scene.collection.objects.link(cam)
+cam.location = (100, -150, 80)
+cam.rotation_euler = (1.1, 0, 0.7)
+bpy.context.scene.camera = cam
+
+# Set up light
+light_data = bpy.data.lights.new(name="Light", type='SUN')
+light = bpy.data.objects.new(name="Light", object_data=light_data)
+bpy.context.collection.objects.link(light)
+light.location = (50, -100, 150)
+
+# Render settings
+bpy.context.scene.render.filepath = os.path.join(os.getcwd(), "render/output.png")
+bpy.context.scene.render.image_settings.file_format = 'PNG'
+
+# Render image
+bpy.ops.render.render(write_still=True)


### PR DESCRIPTION
Add steps for converting STEP files to STL using FreeCAD and rendering with Blender. Fix commands in the KiCad export workflow for ERC and DRC checks, and include missing exports for growbeam.stl and growbeam.png.